### PR TITLE
Implement Grant Registrar

### DIFF
--- a/src/GrantRegistrar.sol
+++ b/src/GrantRegistrar.sol
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { Ownable } from 'openzeppelin-contracts/contracts/access/Ownable.sol';
+import { IWorldIDGroups } from 'world-id-contracts/interfaces/IWorldIDGroups.sol';
+import { Ownable2Step } from 'openzeppelin-contracts/contracts/access/Ownable2Step.sol';
+
+/// @title GrantRegistrar
+/// @author Worldcoin
+contract GrantRegistrar is Ownable2Step {
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                              CONFIG STORAGE                            ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @dev The WorldID router instance that will be used for managing groups and verifying proofs
+  IWorldIDGroups public worldIdRouter;
+
+  /// @dev The World ID group whose participants can verify with this contract.
+  uint256 public groupId;
+
+  /// @dev The World ID nullifier hash that will be used to verify proofs.
+  uint256 immutable externalNullifierHash;
+
+  /// @dev The maximum grant ID that can be claimed without re-verifying.
+  uint256 public maxGrantId;
+
+  /// @dev The current grant ID.
+  uint256 public currentGrantId;
+
+  /// @dev Whether a nullifier hash has been used already, and if so, the grant ID it was used for. Used to prevent double-signaling.
+  mapping(uint256 => uint256) public nullifierHashes;
+
+  /// @dev The last grant this address will be able to claim before re-registering
+  mapping(address => uint256) public expiryGrantIds;
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                                  ERRORS                                ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Error in case the configuration is invalid.
+  error InvalidConfiguration();
+
+  /// @notice Thrown when attempting to reuse a nullifier
+  error InvalidNullifier();
+
+  /// @notice Emmitted in revert if the owner attempts to resign ownership.
+  error CannotRenounceOwnership();
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                                  EVENTS                                ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Emitted when the contract is initialized
+  /// @param worldIdRouter The WorldID router that will manage groups and verify proofs
+  /// @param groupId The group ID of the World ID
+  /// @param externalNullifierHash The nullifier hash that will be used to verify proofs
+  /// @param maxGrantId The maximum grant ID that can be claimed without re-verifying
+  /// @param currentGrantId The current grant ID
+  event GrantRegistrarInitialized(
+    IWorldIDGroups worldIdRouter,
+    uint256 groupId,
+    uint256 externalNullifierHash,
+    uint256 maxGrantId,
+    uint256 currentGrantId
+  );
+
+  /// @notice Emitted when a user registers their wallet to receive grants
+  /// @param receiver The address that will receive the grants
+  /// @param expiryGrandId The last grant this address will be able to claim before re-registering
+  event WalletRegistered(address receiver, uint256 expiryGrandId);
+
+  /// @notice Emitted when the worldIdRouter is changed
+  /// @param worldIdRouter The new worldIdRouter instance
+  event WorldIdRouterUpdated(IWorldIDGroups worldIdRouter);
+
+  /// @notice Emitted when the groupId is changed
+  /// @param groupId The new groupId
+  event GroupIdUpdated(uint256 groupId);
+
+  /// @notice Emitted when the currentGrandId is changed
+  /// @param currentGrantId The new grantId
+  event CurrentGrantIdUpdated(uint256 currentGrantId);
+
+  /// @notice Emitted when the maxGrantId is changed
+  /// @param maxGrantId The new maxGrantId
+  event MaxGrantIdUpdated(uint256 maxGrantId);
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               CONSTRUCTOR                              ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Deploys a WorldIDAirdrop instance
+  /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
+  /// @param _groupId The group ID of the World ID
+  /// @param _externalNullifierHash The nullifier hash that will be used to verify proofs
+  constructor(
+    IWorldIDGroups _worldIdRouter,
+    uint256 _groupId,
+    uint256 _externalNullifierHash,
+    uint256 _maxGrantId,
+    uint256 _currentGrantId
+  ) Ownable(msg.sender) {
+    if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
+
+    groupId = _groupId;
+    maxGrantId = _maxGrantId;
+    worldIdRouter = _worldIdRouter;
+    currentGrantId = _currentGrantId;
+    externalNullifierHash = _externalNullifierHash;
+
+    emit GrantRegistrarInitialized(
+      worldIdRouter,
+      groupId,
+      externalNullifierHash,
+      maxGrantId,
+      currentGrantId
+    );
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               MAIN LOGIC                                ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Registers a wallet to receive grants
+  /// @param receiver The address that will be able to claim grants
+  /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
+  /// @param nullifierHash The nullifier for this proof, preventing double signaling
+  /// @param proof The zero knowledge proof that demonstrates the claimer has a verified World ID
+  /// @dev hashToField function docs are in lib/world-id-contracts/src/libraries/ByteHasher.sol
+  function verify(
+    address receiver,
+    uint256 root,
+    uint256 nullifierHash,
+    uint256[8] calldata proof
+  ) external payable {
+    if (nullifierHashes[nullifierHash] <= currentGrantId) revert InvalidNullifier();
+
+    worldIdRouter.verifyProof(
+      root,
+      groupId,
+      uint256(keccak256(abi.encodePacked(receiver, maxGrantId))) >> 8,
+      nullifierHash,
+      externalNullifierHash,
+      proof
+    );
+
+    expiryGrantIds[receiver] = maxGrantId;
+    nullifierHashes[nullifierHash] = maxGrantId;
+  }
+
+  /// @notice Checks if a grant can be claimed by a receiver
+  /// @param receiver The address that will be able to claim grants
+  /// @param grantId The grant ID to check
+  /// @return Whether the grant can be claimed.
+  function canClaimGrant(address receiver, uint256 grantId) external view returns (bool) {
+    return expiryGrantIds[receiver] >= grantId;
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               CONFIG LOGIC                             ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  // @notice Update the worldIdRouter
+  /// @param _worldIdRouter The new worldIdRouter
+  function setWorldIdRouter(IWorldIDGroups _worldIdRouter) external onlyOwner {
+    if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
+
+    worldIdRouter = _worldIdRouter;
+    emit WorldIdRouterUpdated(_worldIdRouter);
+  }
+
+  /// @notice Update the groupId
+  /// @param _groupId The new groupId
+  function setGroupId(uint256 _groupId) external onlyOwner {
+    groupId = _groupId;
+
+    emit GroupIdUpdated(_groupId);
+  }
+
+  /// @notice Update the current grant ID
+  /// @param _currentGrantId The new current grant ID
+  function setCurrentGrant(uint256 _currentGrantId) external onlyOwner {
+    if (_currentGrantId <= currentGrantId) revert InvalidConfiguration();
+
+    currentGrantId = _currentGrantId;
+    emit CurrentGrantIdUpdated(currentGrantId);
+  }
+
+  /// @notice Update the max grant ID
+  /// @param _maxGrantId The new max grant ID
+  function setMaxGrantId(uint256 _maxGrantId) external onlyOwner {
+    if (_maxGrantId <= currentGrantId) revert InvalidConfiguration();
+
+    maxGrantId = _maxGrantId;
+    emit MaxGrantIdUpdated(maxGrantId);
+  }
+
+  /// @notice Prevents the owner from renouncing ownership
+  /// @dev onlyOwner
+  function renounceOwnership() public view override onlyOwner {
+    revert CannotRenounceOwnership();
+  }
+}

--- a/src/RecurringGrantDropWithRegistrar.sol
+++ b/src/RecurringGrantDropWithRegistrar.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { IGrant } from './IGrant.sol';
+import { GrantRegistrar } from './GrantRegistrar.sol';
+import { Ownable } from 'openzeppelin-contracts/contracts/access/Ownable.sol';
+import { ERC20 } from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
+import { ECDSA } from 'openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol';
+import { Ownable2Step } from 'openzeppelin-contracts/contracts/access/Ownable2Step.sol';
+import { SafeERC20 } from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+
+/// @title RecurringGrantDrop
+/// @author Worldcoin
+contract RecurringGrantDrop is Ownable2Step {
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                              CONFIG STORAGE                            ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @dev The GrantRegistrar instance that will be used for gating claims
+  GrantRegistrar public grantRegistrar;
+
+  /// @notice The ERC20 token airdropped
+  ERC20 public token;
+
+  /// @notice The address that holds the tokens that are being airdropped
+  /// @dev Make sure the holder has approved spending for this contract!
+  address public holder;
+
+  /// @notice The grant instance used
+  IGrant public grant;
+
+  /// @notice Whether a particular grantId has been claimed by an address
+  mapping(uint256 => mapping(address => bool)) public hasClaimedGrant;
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                                  ERRORS                                ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Error in case the configuration is invalid.
+  error InvalidConfiguration();
+
+  /// @notice Error in case the receiver can't claim the grant or is the zero address.
+  error InvalidReceiver();
+
+  /// @notice Error in case the receiver is zero address.
+  error InvalidTimestamp();
+
+  /// @notice Thrown when passed an invalid caller address
+  error UnauthorizedSigner();
+
+  /// @notice Emmitted in revert if the owner attempts to resign ownership.
+  error CannotRenounceOwnership();
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                                  EVENTS                                ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Emitted when a grant is successfully claimed
+  /// @param _grantRegistrar The GrantRegistrar that will gate the claims
+  /// @param _token The ERC20 token that will be airdropped
+  /// @param _holder The address holding the tokens that will be airdropped
+  /// @param _grant The grant that contains the amounts and validity
+  event RecurringGrantDropInitialized(
+    GrantRegistrar _grantRegistrar,
+    ERC20 _token,
+    address _holder,
+    IGrant _grant
+  );
+
+  /// @notice Emitted when a grant is successfully claimed
+  /// @param receiver The address that received the tokens
+  event GrantClaimed(uint256 grantId, address receiver);
+
+  /// @notice Emitted when the grantRegistrar is changed
+  /// @param grantRegistrar The new GrantRegistrar instance
+  event GrantRegistrarUpdated(GrantRegistrar grantRegistrar);
+
+  /// @notice Emitted when the token is changed
+  /// @param token The new token
+  event TokenUpdated(ERC20 token);
+
+  /// @notice Emitted when the holder is changed
+  /// @param holder The new holder
+  event HolderUpdated(address holder);
+
+  /// @notice Emitted when the grant is changed
+  /// @param grant The new grant instance
+  event GrantUpdated(IGrant grant);
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               CONSTRUCTOR                              ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Deploys a WorldIDAirdrop instance
+  /// @param _grantRegistrar The GrantRegistrar that will gate the claims
+  /// @param _token The ERC20 token that will be airdropped
+  /// @param _holder The address holding the tokens that will be airdropped
+  /// @param _grant The grant that contains the amounts and validity
+  constructor(
+    GrantRegistrar _grantRegistrar,
+    ERC20 _token,
+    address _holder,
+    IGrant _grant
+  ) Ownable(msg.sender) {
+    if (address(_grantRegistrar) == address(0)) revert InvalidConfiguration();
+    if (address(_token) == address(0)) revert InvalidConfiguration();
+    if (address(_holder) == address(0)) revert InvalidConfiguration();
+    if (address(_grant) == address(0)) revert InvalidConfiguration();
+
+    grantRegistrar = _grantRegistrar;
+    token = _token;
+    holder = _holder;
+    grant = _grant;
+
+    emit RecurringGrantDropInitialized(grantRegistrar, token, holder, grant);
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               CLAIM LOGIC                               ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Claim the airdrop
+  /// @param grantId The grant ID to claim
+  /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
+  function claim(uint256 grantId, address receiver) external {
+    checkClaim(grantId, receiver);
+
+    hasClaimedGrant[grantId][receiver] = true;
+
+    SafeERC20.safeTransferFrom(token, holder, receiver, grant.getAmount(grantId));
+
+    emit GrantClaimed(grantId, receiver);
+  }
+
+  /// @notice Check whether a claim is valid
+  /// @param grantId The grant ID to claim
+  /// @param receiver The address that will receive the tokens
+  function checkClaim(uint256 grantId, address receiver) public view {
+    if (
+      receiver == address(0) ||
+      hasClaimedGrant[grantId][receiver] ||
+      !grantRegistrar.canClaimGrant(receiver, grantId)
+    ) revert InvalidReceiver();
+
+    grant.checkValidity(grantId);
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               CONFIG LOGIC                             ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Update the grantRegistrar
+  /// @param _grantRegistrar The new grantRegistrar
+  function setGrantRegistrar(GrantRegistrar _grantRegistrar) external onlyOwner {
+    if (address(_grantRegistrar) == address(0)) revert InvalidConfiguration();
+
+    grantRegistrar = _grantRegistrar;
+    emit GrantRegistrarUpdated(_grantRegistrar);
+  }
+
+  /// @notice Update the token
+  /// @param _token The new token
+  function setToken(ERC20 _token) external onlyOwner {
+    if (address(_token) == address(0)) revert InvalidConfiguration();
+    token = _token;
+
+    emit TokenUpdated(_token);
+  }
+
+  /// @notice Update the holder
+  /// @param _holder The new holder
+  function setHolder(address _holder) external onlyOwner {
+    if (address(_holder) == address(0)) revert InvalidConfiguration();
+    holder = _holder;
+
+    emit HolderUpdated(holder);
+  }
+
+  /// @notice Update the grant
+  /// @param _grant The new grant
+  function setGrant(IGrant _grant) external onlyOwner {
+    if (address(_grant) == address(0)) revert InvalidConfiguration();
+
+    grant = _grant;
+    emit GrantUpdated(_grant);
+  }
+
+  /// @notice Prevents the owner from renouncing ownership
+  /// @dev onlyOwner
+  function renounceOwnership() public view override onlyOwner {
+    revert CannotRenounceOwnership();
+  }
+}


### PR DESCRIPTION
Adds a `GrantRegistrar` contract, which keeps track of which addresses are allowed to mint grants, and enables verifying an address for multiple future grants, saving on gas when claiming a grant.

## Usage

- Deploy `GrantRegistrar` with World ID details (`router`, `groupId`, and `externalNullifierHash`), the current grant id, and the maximum grant id that will be claimable (more on this last one below).
- Deploy `RecurringGrantDropWithRegistrar` with the address of the `GrantRegistrar` contract (and the other parameters that were already present on the previous `RecurringGrantDrop`).
- To verify, users must first call `GrantRegistrar.verify` with the receiver address and a valid World ID proof for that address and `maxGrantId`.
- Then, for the next `currentGrandId...maxGrantId` grants, users can simply call `RecurringGrantDropWithRegistrar.claim(uint256 grantId, address receiver)`.
- Every time a new grant gets deployed, the contract's owner should call `GrantRegistrar.setCurrentGrant` and `GrantRegistrar.setMaxGrantId` to update the contract's understanding of the current grant and the max grant users should be able to claim.

## Design Considerations

- The `GrantRegistrar` works with both `currentGrantId` and `maxGrantId` to allow for rolling registrations. A simpler design would make it so that, if allowing users to verify for $n$ grants at a time, users registering for the first time on grant $n$ would need to re-verify for the next grant.
- When verifying their wallet, the provided proof must include both the `receiver` address and the contract's current `maxGrantId` in the signal. This prevents re-verifying by simply reusing the previous verification's proof.
- For maximum flexibility, the `maxGrantId` is not computed by adding some constant to the `currentGrantId` but set dynamically by the contract's owner. This could probably get updated to a constant if we expect grants to always follow the same incrementing pattern.
- For simplicity, the new `RecurringGrantDropWithRegistrar` contract does not include logic for handling reservations. It is expected the currently deployed `RecurringGrantDrop` contract will continue to handle reservations.