### PR TITLE
Worldchain Reservations-only contract

### DIFF
--- a/script/RecurringGrantDropReservations.s.sol
+++ b/script/RecurringGrantDropReservations.s.sol
@@ -5,9 +5,8 @@ import {Script} from "forge-std/Script.sol";
 import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import {IWorldIDGroups} from "world-id-contracts/interfaces/IWorldIDGroups.sol";
 import {RecurringGrantDropReservations} from "src/RecurringGrantDropReservations.sol";
-import {RecurringGrantDrop} from "src/RecurringGrantDropPreGrant4.sol";
-import {WLDGrant} from "src/WLDGrantPreGrant4_new.sol";
-import {IGrant} from "src/IGrantPreGrant4.sol";
+import {WLDGrantReservations} from "src/WLDGrantReservations.sol";
+import {IGrantReservations} from "src/IGrantReservations.sol";
 
 /// @title Deployment script for RecurringGrantDrop
 /// @author Worldcoin
@@ -16,7 +15,7 @@ import {IGrant} from "src/IGrantPreGrant4.sol";
 /// Can be run by executing `make deploy-airdrop` (assumes a deployment of world-id-contracts or a mock)
 contract DeployRecurringGrantDropReservations is Script {
     RecurringGrantDropReservations public airdrop;
-    IGrant grant;
+    IGrantReservations grant;
 
     ///////////////////////////////////////////////////////////////////
     ///                            CONFIG                           ///
@@ -35,7 +34,6 @@ contract DeployRecurringGrantDropReservations is Script {
         abi.decode(vm.parseJson(json, ".worldIDRouterAddress"), (address));
     IWorldIDGroups public worldIdRouter = IWorldIDGroups(worldIDRouterAddress);
 
-    RecurringGrantDrop public recurringGrantDropAddress = RecurringGrantDrop(abi.decode(vm.parseJson(json, ".recurringGrantDropAddress"), (address)));
     uint256 public groupId = abi.decode(vm.parseJson(json, ".groupId"), (uint256));
     address public erc20Address = abi.decode(vm.parseJson(json, ".erc20Address"), (address));
     address public holder = abi.decode(vm.parseJson(json, ".holderAddress"), (address));
@@ -45,9 +43,9 @@ contract DeployRecurringGrantDropReservations is Script {
     function run() external {
         vm.startBroadcast(privateKey);
 
-        grant = new WLDGrant();
+        grant = new WLDGrantReservations();
 
-        airdrop = new RecurringGrantDropReservations(worldIdRouter, groupId, token, holder, grant, recurringGrantDropAddress);
+        airdrop = new RecurringGrantDropReservations(worldIdRouter, groupId, token, holder, grant);
 
         vm.stopBroadcast();
     }

--- a/script/deploy.js
+++ b/script/deploy.js
@@ -277,7 +277,6 @@ async function deployAirdropReservations(config) {
   await getWorldIDIdentityManagerRouterAddress(config);
   await saveConfiguration(config);
   await getAirdropParameters(config);
-  await getRecurringGrantDropAddress(config);
 
   const spinner = ora(`Deploying RecurringGrantDropReservations contract...`).start();
 

--- a/src/IGrantReservations.sol
+++ b/src/IGrantReservations.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface IGrantReservations {
+    /// @notice Error in case the grant is invalid.
+    error InvalidGrant();
+
+    /// @notice Error in case the grant configuration is invalid.
+    error InvalidConfiguration();
+
+    /// @notice Returns the current grant id.
+    function getCurrentId() external view returns (uint256);
+
+    /// @notice Returns the amount of tokens for a grant.
+    /// @notice This may contain more complicated logic and is therefore not just a member variable.
+    /// @param grantId The grant id to get the amount for.
+    function getAmount(uint256 grantId) external view returns (uint256);
+    
+    /// @notice Calculates the grant id for a given timestamp.
+    /// @param timestamp The timestamp to calculate the grant id for.
+    function calculateId(uint256 timestamp) external view returns (uint256);
+
+    /// @notice Checks whether a reservation is valid.
+    /// @param timestamp The timestamp to check the reservation for.
+    function checkReservationValidity(uint256 timestamp) external view;
+}

--- a/src/RecurringGrantDropReservations.sol
+++ b/src/RecurringGrantDropReservations.sol
@@ -12,277 +12,277 @@ import { ECDSA } from 'openzeppelin-contracts/contracts/utils/cryptography/ECDSA
 /// @title RecurringGrantDropReservations
 /// @author Worldcoin
 contract RecurringGrantDropReservations is Ownable2Step {
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                              CONFIG STORAGE                            ///
-    //////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                              CONFIG STORAGE                            ///
+  //////////////////////////////////////////////////////////////////////////////
 
-    /// @dev The prefix used for the grant ID external nullifier hash
-    uint256 public constant WORLDCHAIN_NULLIFIER_HASH_PREFIX =
-        0x1E00000000000000000000000000000000000000000000000000000000000000;
+  /// @dev The constant used for the grant ID external nullifier hash
+  uint256 public constant WORLDCHAIN_NULLIFIER_HASH_CONSTANT =
+    0x1E00000000000000000000000000000000000000000000000000000000000000;
 
-    /// @dev The WorldID router instance that will be used for managing groups and verifying proofs
-    IWorldIDGroups public worldIdRouter;
+  /// @dev The WorldID router instance that will be used for managing groups and verifying proofs
+  IWorldIDGroups public worldIdRouter;
 
-    /// @dev The World ID group whose participants can claim this airdrop
-    uint256 public groupId;
+  /// @dev The World ID group whose participants can claim this airdrop
+  uint256 public groupId;
 
-    /// @notice The ERC20 token airdropped
-    ERC20 public token;
+  /// @notice The ERC20 token airdropped
+  ERC20 public token;
 
-    /// @notice The address that holds the tokens that are being airdropped
-    /// @dev Make sure the holder has approved spending for this contract!
-    address public holder;
+  /// @notice The address that holds the tokens that are being airdropped
+  /// @dev Make sure the holder has approved spending for this contract!
+  address public holder;
 
-    /// @notice The grant instance used
-    IGrantReservations public grant;
+  /// @notice The grant instance used
+  IGrantReservations public grant;
 
-    /// @dev Whether a nullifier hash has been used already. Used to prevent double-signaling
-    mapping(uint256 => bool) public nullifierHashes;
+  /// @dev Whether a nullifier hash has been used already. Used to prevent double-signaling
+  mapping(uint256 => bool) public nullifierHashes;
 
-    /// @dev Allowed addresses to sign a reservation
-    mapping(address => bool) internal allowedSigners;
+  /// @dev Allowed addresses to sign a reservation
+  mapping(address => bool) internal allowedSigners;
 
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                                  ERRORS                                ///
-    //////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                                  ERRORS                                ///
+  //////////////////////////////////////////////////////////////////////////////
 
-    /// @notice Error in case the configuration is invalid.
-    error InvalidConfiguration();
+  /// @notice Error in case the configuration is invalid.
+  error InvalidConfiguration();
 
-    /// @notice Error in case the receiver is zero address.
-    error InvalidReceiver();
+  /// @notice Error in case the receiver is zero address.
+  error InvalidReceiver();
 
-    /// @notice Error in case the receiver is zero address.
-    error InvalidTimestamp();
+  /// @notice Error in case the receiver is zero address.
+  error InvalidTimestamp();
 
-    /// @notice Thrown when passed an invalid caller address
-    error InvalidReservationSigner();
+  /// @notice Thrown when passed an invalid caller address
+  error InvalidReservationSigner();
 
-    /// @notice Thrown when passed an invalid caller address
-    error UnauthorizedSigner();
+  /// @notice Thrown when passed an invalid caller address
+  error UnauthorizedSigner();
 
-    /// @notice Thrown when attempting to reuse a nullifier
-    error InvalidNullifier();
+  /// @notice Thrown when attempting to reuse a nullifier
+  error InvalidNullifier();
 
-    /// @notice Emmitted in revert if the owner attempts to resign ownership.
-    error CannotRenounceOwnership();
+  /// @notice Emmitted in revert if the owner attempts to resign ownership.
+  error CannotRenounceOwnership();
 
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                                  EVENTS                                ///
-    //////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                                  EVENTS                                ///
+  //////////////////////////////////////////////////////////////////////////////
 
-    /// @notice Emitted when a grant is successfully claimed
-    /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
-    /// @param _groupId The group ID of the World ID
-    /// @param _token The ERC20 token that will be airdropped
-    /// @param _holder The address holding the tokens that will be airdropped
-    /// @param _grant The grant that contains the amounts and validity
-    event RecurringGrantDropInitialized(
-        IWorldIDGroups _worldIdRouter,
-        uint256 _groupId,
-        ERC20 _token,
-        address _holder,
-        IGrantReservations _grant
+  /// @notice Emitted when a grant is successfully claimed
+  /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
+  /// @param _groupId The group ID of the World ID
+  /// @param _token The ERC20 token that will be airdropped
+  /// @param _holder The address holding the tokens that will be airdropped
+  /// @param _grant The grant that contains the amounts and validity
+  event RecurringGrantDropInitialized(
+    IWorldIDGroups _worldIdRouter,
+    uint256 _groupId,
+    ERC20 _token,
+    address _holder,
+    IGrantReservations _grant
+  );
+
+  /// @notice Emitted when a grant is successfully claimed
+  /// @param receiver The address that received the tokens
+  event GrantClaimed(uint256 grantId, address receiver);
+
+  /// @notice Emitted when the worldIdRouter is changed
+  /// @param worldIdRouter The new worldIdRouter instance
+  event WorldIdRouterUpdated(IWorldIDGroups worldIdRouter);
+
+  /// @notice Emitted when the groupId is changed
+  /// @param groupId The new groupId
+  event GroupIdUpdated(uint256 groupId);
+
+  /// @notice Emitted when the token is changed
+  /// @param token The new token
+  event TokenUpdated(ERC20 token);
+
+  /// @notice Emitted when the holder is changed
+  /// @param holder The new holder
+  event HolderUpdated(address holder);
+
+  /// @notice Emitted when the grant is changed
+  /// @param grant The new grant instance
+  event GrantUpdated(IGrantReservations grant);
+
+  /// @notice Emitted when an allowed reservation signer is added
+  /// @param signer The new signer
+  event AllowedReservationSignerAdded(address signer);
+
+  /// @notice Emitted when an allowed reservation signer is removed
+  /// @param signer The new signer
+  event AllowedReservationSignerRemoved(address signer);
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               CONSTRUCTOR                              ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Deploys a WorldIDAirdrop instance
+  /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
+  /// @param _groupId The group ID of the World ID
+  /// @param _token The ERC20 token that will be airdropped
+  /// @param _holder The address holding the tokens that will be airdropped
+  /// @param _grant The grant that contains the amounts and validity
+  constructor(
+    IWorldIDGroups _worldIdRouter,
+    uint256 _groupId,
+    ERC20 _token,
+    address _holder,
+    IGrantReservations _grant
+  ) Ownable(msg.sender) {
+    if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
+    if (address(_token) == address(0)) revert InvalidConfiguration();
+    if (address(_holder) == address(0)) revert InvalidConfiguration();
+    if (address(_grant) == address(0)) revert InvalidConfiguration();
+
+    worldIdRouter = _worldIdRouter;
+    groupId = _groupId;
+    token = _token;
+    holder = _holder;
+    grant = _grant;
+
+    emit RecurringGrantDropInitialized(worldIdRouter, groupId, token, holder, grant);
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               CLAIM LOGIC                               ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Claim a reserved grant from the past
+  /// @param timestamp The timestamp of the reservation
+  /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
+  /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
+  /// @param nullifierHash The nullifier for this proof, preventing double signaling
+  /// @param proof The zero knowledge proof that demonstrates the claimer has a verified World ID
+  /// @param signature The signature of the reservation
+  function claimReserved(
+    uint256 timestamp,
+    address receiver,
+    uint256 root,
+    uint256 nullifierHash,
+    uint256[8] calldata proof,
+    bytes calldata signature
+  ) external {
+    uint256 grantId = grant.calculateId(timestamp);
+    checkClaimReserved(timestamp, receiver, root, nullifierHash, proof, signature);
+
+    nullifierHashes[nullifierHash] = true;
+
+    SafeERC20.safeTransferFrom(token, holder, receiver, grant.getAmount(grantId));
+
+    emit GrantClaimed(grantId, receiver);
+  }
+
+  /// @notice Check whether a reservation is valid
+  /// @param timestamp The timestamp of the reservation
+  /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
+  /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
+  /// @param nullifierHash The nullifier for this proof, preventing double signaling
+  /// @param proof The zero knowledge proof, array of 8 uint256 elements, demonstrating that the claimer has a verified World ID
+  /// @param signature The off-chain signature of the reservation.
+  function checkClaimReserved(
+    uint256 timestamp,
+    address receiver,
+    uint256 root,
+    uint256 nullifierHash,
+    uint256[8] calldata proof,
+    bytes calldata signature
+  ) public {
+    uint256 grantId = grant.calculateId(timestamp);
+
+    if (receiver == address(0)) revert InvalidReceiver();
+    if (timestamp > block.timestamp) revert InvalidTimestamp();
+
+    if (nullifierHashes[nullifierHash]) revert InvalidNullifier();
+
+    grant.checkReservationValidity(timestamp);
+
+    address signer = ECDSA.recover(keccak256(abi.encode(timestamp, nullifierHash)), signature);
+    if (!allowedSigners[signer]) revert UnauthorizedSigner();
+
+    worldIdRouter.verifyProof(
+      root,
+      groupId,
+      uint256(keccak256(abi.encodePacked(receiver))) >> 8,
+      nullifierHash,
+      grantId + WORLDCHAIN_NULLIFIER_HASH_CONSTANT,
+      proof
     );
+  }
 
-    /// @notice Emitted when a grant is successfully claimed
-    /// @param receiver The address that received the tokens
-    event GrantClaimed(uint256 grantId, address receiver);
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               CONFIG LOGIC                             ///
+  //////////////////////////////////////////////////////////////////////////////
 
-    /// @notice Emitted when the worldIdRouter is changed
-    /// @param worldIdRouter The new worldIdRouter instance
-    event WorldIdRouterUpdated(IWorldIDGroups worldIdRouter);
+  /// @notice Add a caller to the list of allowed callers
+  /// @param _signer The address to add
+  function addAllowedReservationSigner(address _signer) external onlyOwner {
+    if (_signer == address(0)) revert InvalidReservationSigner();
+    allowedSigners[_signer] = true;
 
-    /// @notice Emitted when the groupId is changed
-    /// @param groupId The new groupId
-    event GroupIdUpdated(uint256 groupId);
+    emit AllowedReservationSignerAdded(_signer);
+  }
 
-    /// @notice Emitted when the token is changed
-    /// @param token The new token
-    event TokenUpdated(ERC20 token);
+  /// @notice Remove a signer to the list of allowed signers
+  /// @param _signer The address to remove
+  function removeAllowedReservationSigner(address _signer) external onlyOwner {
+    if (_signer == address(0)) revert InvalidReservationSigner();
+    allowedSigners[_signer] = false;
 
-    /// @notice Emitted when the holder is changed
-    /// @param holder The new holder
-    event HolderUpdated(address holder);
+    emit AllowedReservationSignerRemoved(_signer);
+  }
 
-    /// @notice Emitted when the grant is changed
-    /// @param grant The new grant instance
-    event GrantUpdated(IGrantReservations grant);
+  /// @notice Update the worldIdRouter
+  /// @param _worldIdRouter The new worldIdRouter
+  function setWorldIdRouter(IWorldIDGroups _worldIdRouter) external onlyOwner {
+    if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
 
-    /// @notice Emitted when an allowed reservation signer is added
-    /// @param signer The new signer
-    event AllowedReservationSignerAdded(address signer);
+    worldIdRouter = _worldIdRouter;
+    emit WorldIdRouterUpdated(_worldIdRouter);
+  }
 
-    /// @notice Emitted when an allowed reservation signer is removed
-    /// @param signer The new signer
-    event AllowedReservationSignerRemoved(address signer);
+  /// @notice Update the groupId
+  /// @param _groupId The new worldIdRouter
+  function setGroupId(uint256 _groupId) external onlyOwner {
+    groupId = _groupId;
 
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                               CONSTRUCTOR                              ///
-    //////////////////////////////////////////////////////////////////////////////
+    emit GroupIdUpdated(_groupId);
+  }
 
-    /// @notice Deploys a WorldIDAirdrop instance
-    /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
-    /// @param _groupId The group ID of the World ID
-    /// @param _token The ERC20 token that will be airdropped
-    /// @param _holder The address holding the tokens that will be airdropped
-    /// @param _grant The grant that contains the amounts and validity
-    constructor(
-        IWorldIDGroups _worldIdRouter,
-        uint256 _groupId,
-        ERC20 _token,
-        address _holder,
-        IGrantReservations _grant
-    ) Ownable(msg.sender) {
-        if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
-        if (address(_token) == address(0)) revert InvalidConfiguration();
-        if (address(_holder) == address(0)) revert InvalidConfiguration();
-        if (address(_grant) == address(0)) revert InvalidConfiguration();
+  /// @notice Update the token
+  /// @param _token The new token
+  function setToken(ERC20 _token) external onlyOwner {
+    if (address(_token) == address(0)) revert InvalidConfiguration();
+    token = _token;
 
-        worldIdRouter = _worldIdRouter;
-        groupId = _groupId;
-        token = _token;
-        holder = _holder;
-        grant = _grant;
+    emit TokenUpdated(_token);
+  }
 
-        emit RecurringGrantDropInitialized(worldIdRouter, groupId, token, holder, grant);
-    }
+  /// @notice Update the holder
+  /// @param _holder The new holder
+  function setHolder(address _holder) external onlyOwner {
+    if (address(_holder) == address(0)) revert InvalidConfiguration();
+    holder = _holder;
 
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                               CLAIM LOGIC                               ///
-    //////////////////////////////////////////////////////////////////////////////
+    emit HolderUpdated(holder);
+  }
 
-    /// @notice Claim a reserved grant from the past
-    /// @param timestamp The timestamp of the reservation
-    /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
-    /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
-    /// @param nullifierHash The nullifier for this proof, preventing double signaling
-    /// @param proof The zero knowledge proof that demonstrates the claimer has a verified World ID
-    /// @param signature The signature of the reservation
-    function claimReserved(
-        uint256 timestamp,
-        address receiver,
-        uint256 root,
-        uint256 nullifierHash,
-        uint256[8] calldata proof,
-        bytes calldata signature
-    ) external {
-        uint256 grantId = grant.calculateId(timestamp);
-        checkClaimReserved(timestamp, receiver, root, nullifierHash, proof, signature);
+  /// @notice Update the grant
+  /// @param _grant The new grant
+  function setGrant(IGrantReservations _grant) external onlyOwner {
+    if (address(_grant) == address(0)) revert InvalidConfiguration();
 
-        nullifierHashes[nullifierHash] = true;
+    grant = _grant;
+    emit GrantUpdated(_grant);
+  }
 
-        SafeERC20.safeTransferFrom(token, holder, receiver, grant.getAmount(grantId));
-
-        emit GrantClaimed(grantId, receiver);
-    }
-
-    /// @notice Check whether a reservation is valid
-    /// @param timestamp The timestamp of the reservation
-    /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
-    /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
-    /// @param nullifierHash The nullifier for this proof, preventing double signaling
-    /// @param proof The zero knowledge proof, array of 8 uint256 elements, demonstrating that the claimer has a verified World ID
-    /// @param signature The off-chain signature of the reservation.
-    function checkClaimReserved(
-        uint256 timestamp,
-        address receiver,
-        uint256 root,
-        uint256 nullifierHash,
-        uint256[8] calldata proof,
-        bytes calldata signature
-    ) public {
-        uint256 grantId = grant.calculateId(timestamp);
-
-        if (receiver == address(0)) revert InvalidReceiver();
-        if (timestamp > block.timestamp) revert InvalidTimestamp();
-
-        if (nullifierHashes[nullifierHash]) revert InvalidNullifier();
-
-        grant.checkReservationValidity(timestamp);
-
-        address signer = ECDSA.recover(keccak256(abi.encode(timestamp, nullifierHash)), signature);
-        if (!allowedSigners[signer]) revert UnauthorizedSigner();
-
-        worldIdRouter.verifyProof(
-            root,
-            groupId,
-            uint256(keccak256(abi.encodePacked(receiver))) >> 8,
-            nullifierHash,
-            grantId + WORLDCHAIN_NULLIFIER_HASH_PREFIX,
-            proof
-        );
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                               CONFIG LOGIC                             ///
-    //////////////////////////////////////////////////////////////////////////////
-
-    /// @notice Add a caller to the list of allowed callers
-    /// @param _signer The address to add
-    function addAllowedReservationSigner(address _signer) external onlyOwner {
-        if (_signer == address(0)) revert InvalidReservationSigner();
-        allowedSigners[_signer] = true;
-
-        emit AllowedReservationSignerAdded(_signer);
-    }
-
-    /// @notice Remove a signer to the list of allowed signers
-    /// @param _signer The address to remove
-    function removeAllowedReservationSigner(address _signer) external onlyOwner {
-        if (_signer == address(0)) revert InvalidReservationSigner();
-        allowedSigners[_signer] = false;
-
-        emit AllowedReservationSignerRemoved(_signer);
-    }
-
-    /// @notice Update the worldIdRouter
-    /// @param _worldIdRouter The new worldIdRouter
-    function setWorldIdRouter(IWorldIDGroups _worldIdRouter) external onlyOwner {
-        if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
-
-        worldIdRouter = _worldIdRouter;
-        emit WorldIdRouterUpdated(_worldIdRouter);
-    }
-
-    /// @notice Update the groupId
-    /// @param _groupId The new worldIdRouter
-    function setGroupId(uint256 _groupId) external onlyOwner {
-        groupId = _groupId;
-
-        emit GroupIdUpdated(_groupId);
-    }
-
-    /// @notice Update the token
-    /// @param _token The new token
-    function setToken(ERC20 _token) external onlyOwner {
-        if (address(_token) == address(0)) revert InvalidConfiguration();
-        token = _token;
-
-        emit TokenUpdated(_token);
-    }
-
-    /// @notice Update the holder
-    /// @param _holder The new holder
-    function setHolder(address _holder) external onlyOwner {
-        if (address(_holder) == address(0)) revert InvalidConfiguration();
-        holder = _holder;
-
-        emit HolderUpdated(holder);
-    }
-
-    /// @notice Update the grant
-    /// @param _grant The new grant
-    function setGrant(IGrantReservations _grant) external onlyOwner {
-        if (address(_grant) == address(0)) revert InvalidConfiguration();
-
-        grant = _grant;
-        emit GrantUpdated(_grant);
-    }
-
-    /// @notice Prevents the owner from renouncing ownership
-    /// @dev onlyOwner
-    function renounceOwnership() public view override onlyOwner {
-        revert CannotRenounceOwnership();
-    }
+  /// @notice Prevents the owner from renouncing ownership
+  /// @dev onlyOwner
+  function renounceOwnership() public view override onlyOwner {
+    revert CannotRenounceOwnership();
+  }
 }

--- a/src/RecurringGrantDropReservations.sol
+++ b/src/RecurringGrantDropReservations.sol
@@ -1,284 +1,288 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
-import {Ownable2Step} from "openzeppelin-contracts/contracts/access/Ownable2Step.sol";
-import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
-import {IGrantReservations} from "./IGrantReservations.sol";
-import {IWorldIDGroups} from "world-id-contracts/interfaces/IWorldIDGroups.sol";
-import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+import { Ownable } from 'openzeppelin-contracts/contracts/access/Ownable.sol';
+import { Ownable2Step } from 'openzeppelin-contracts/contracts/access/Ownable2Step.sol';
+import { SafeERC20 } from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import { ERC20 } from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
+import { IGrantReservations } from './IGrantReservations.sol';
+import { IWorldIDGroups } from 'world-id-contracts/interfaces/IWorldIDGroups.sol';
+import { ECDSA } from 'openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol';
 
 /// @title RecurringGrantDropReservations
 /// @author Worldcoin
 contract RecurringGrantDropReservations is Ownable2Step {
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                              CONFIG STORAGE                            ///
-    //////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                              CONFIG STORAGE                            ///
+  //////////////////////////////////////////////////////////////////////////////
 
-    /// @dev The WorldID router instance that will be used for managing groups and verifying proofs
-    IWorldIDGroups public worldIdRouter;
+  /// @dev The prefix used for the grant ID external nullifier hash
+  uint256 public constant WORLDCHAIN_NULLIFIER_HASH_PREFIX =
+    0x1E00000000000000000000000000000000000000000000000000000000000000;
 
-    /// @dev The World ID group whose participants can claim this airdrop
-    uint256 public groupId;
+  /// @dev The WorldID router instance that will be used for managing groups and verifying proofs
+  IWorldIDGroups public worldIdRouter;
 
-    /// @notice The ERC20 token airdropped
-    ERC20 public token;
+  /// @dev The World ID group whose participants can claim this airdrop
+  uint256 public groupId;
 
-    /// @notice The address that holds the tokens that are being airdropped
-    /// @dev Make sure the holder has approved spending for this contract!
-    address public holder;
+  /// @notice The ERC20 token airdropped
+  ERC20 public token;
 
-    /// @notice The grant instance used
-    IGrantReservations public grant;
+  /// @notice The address that holds the tokens that are being airdropped
+  /// @dev Make sure the holder has approved spending for this contract!
+  address public holder;
 
-    /// @dev Whether a nullifier hash has been used already. Used to prevent double-signaling
-    mapping(uint256 => bool) public nullifierHashes;
+  /// @notice The grant instance used
+  IGrantReservations public grant;
 
-    /// @dev Allowed addresses to sign a reservation
-    mapping(address => bool) internal allowedSigners;
+  /// @dev Whether a nullifier hash has been used already. Used to prevent double-signaling
+  mapping(uint256 => bool) public nullifierHashes;
 
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                                  ERRORS                                ///
-    //////////////////////////////////////////////////////////////////////////////
+  /// @dev Allowed addresses to sign a reservation
+  mapping(address => bool) internal allowedSigners;
 
-    /// @notice Error in case the configuration is invalid.
-    error InvalidConfiguration();
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                                  ERRORS                                ///
+  //////////////////////////////////////////////////////////////////////////////
 
-    /// @notice Error in case the receiver is zero address.
-    error InvalidReceiver();
+  /// @notice Error in case the configuration is invalid.
+  error InvalidConfiguration();
 
-    /// @notice Error in case the receiver is zero address.
-    error InvalidTimestamp();
+  /// @notice Error in case the receiver is zero address.
+  error InvalidReceiver();
 
-    /// @notice Thrown when passed an invalid caller address
-    error InvalidReservationSigner();
+  /// @notice Error in case the receiver is zero address.
+  error InvalidTimestamp();
 
-    /// @notice Thrown when passed an invalid caller address
-    error UnauthorizedSigner();
+  /// @notice Thrown when passed an invalid caller address
+  error InvalidReservationSigner();
 
-    /// @notice Thrown when attempting to reuse a nullifier
-    error InvalidNullifier();
+  /// @notice Thrown when passed an invalid caller address
+  error UnauthorizedSigner();
 
-    /// @notice Emmitted in revert if the owner attempts to resign ownership.
-    error CannotRenounceOwnership();
+  /// @notice Thrown when attempting to reuse a nullifier
+  error InvalidNullifier();
 
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                                  EVENTS                                ///
-    //////////////////////////////////////////////////////////////////////////////
+  /// @notice Emmitted in revert if the owner attempts to resign ownership.
+  error CannotRenounceOwnership();
 
-    /// @notice Emitted when a grant is successfully claimed
-    /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
-    /// @param _groupId The group ID of the World ID
-    /// @param _token The ERC20 token that will be airdropped
-    /// @param _holder The address holding the tokens that will be airdropped
-    /// @param _grant The grant that contains the amounts and validity
-    event RecurringGrantDropInitialized(
-        IWorldIDGroups _worldIdRouter,
-        uint256 _groupId,
-        ERC20 _token,
-        address _holder,
-        IGrantReservations _grant
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                                  EVENTS                                ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Emitted when a grant is successfully claimed
+  /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
+  /// @param _groupId The group ID of the World ID
+  /// @param _token The ERC20 token that will be airdropped
+  /// @param _holder The address holding the tokens that will be airdropped
+  /// @param _grant The grant that contains the amounts and validity
+  event RecurringGrantDropInitialized(
+    IWorldIDGroups _worldIdRouter,
+    uint256 _groupId,
+    ERC20 _token,
+    address _holder,
+    IGrantReservations _grant
+  );
+
+  /// @notice Emitted when a grant is successfully claimed
+  /// @param receiver The address that received the tokens
+  event GrantClaimed(uint256 grantId, address receiver);
+
+  /// @notice Emitted when the worldIdRouter is changed
+  /// @param worldIdRouter The new worldIdRouter instance
+  event WorldIdRouterUpdated(IWorldIDGroups worldIdRouter);
+
+  /// @notice Emitted when the groupId is changed
+  /// @param groupId The new groupId
+  event GroupIdUpdated(uint256 groupId);
+
+  /// @notice Emitted when the token is changed
+  /// @param token The new token
+  event TokenUpdated(ERC20 token);
+
+  /// @notice Emitted when the holder is changed
+  /// @param holder The new holder
+  event HolderUpdated(address holder);
+
+  /// @notice Emitted when the grant is changed
+  /// @param grant The new grant instance
+  event GrantUpdated(IGrantReservations grant);
+
+  /// @notice Emitted when an allowed reservation signer is added
+  /// @param signer The new signer
+  event AllowedReservationSignerAdded(address signer);
+
+  /// @notice Emitted when an allowed reservation signer is removed
+  /// @param signer The new signer
+  event AllowedReservationSignerRemoved(address signer);
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               CONSTRUCTOR                              ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Deploys a WorldIDAirdrop instance
+  /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
+  /// @param _groupId The group ID of the World ID
+  /// @param _token The ERC20 token that will be airdropped
+  /// @param _holder The address holding the tokens that will be airdropped
+  /// @param _grant The grant that contains the amounts and validity
+  constructor(
+    IWorldIDGroups _worldIdRouter,
+    uint256 _groupId,
+    ERC20 _token,
+    address _holder,
+    IGrantReservations _grant
+  ) Ownable(msg.sender) {
+    if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
+    if (address(_token) == address(0)) revert InvalidConfiguration();
+    if (address(_holder) == address(0)) revert InvalidConfiguration();
+    if (address(_grant) == address(0)) revert InvalidConfiguration();
+
+    worldIdRouter = _worldIdRouter;
+    groupId = _groupId;
+    token = _token;
+    holder = _holder;
+    grant = _grant;
+
+    emit RecurringGrantDropInitialized(worldIdRouter, groupId, token, holder, grant);
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               CLAIM LOGIC                               ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// @notice Claim a reserved grant from the past
+  /// @param timestamp The timestamp of the reservation
+  /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
+  /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
+  /// @param nullifierHash The nullifier for this proof, preventing double signaling
+  /// @param proof The zero knowledge proof that demonstrates the claimer has a verified World ID
+  /// @param signature The signature of the reservation
+  function claimReserved(
+    uint256 timestamp,
+    address receiver,
+    uint256 root,
+    uint256 nullifierHash,
+    uint256[8] calldata proof,
+    bytes calldata signature
+  ) external {
+    uint256 grantId = grant.calculateId(timestamp);
+    checkClaimReserved(timestamp, receiver, root, nullifierHash, proof, signature);
+
+    nullifierHashes[nullifierHash] = true;
+
+    SafeERC20.safeTransferFrom(token, holder, receiver, grant.getAmount(grantId));
+
+    emit GrantClaimed(grantId, receiver);
+  }
+
+  /// @notice Check whether a reservation is valid
+  /// @param timestamp The timestamp of the reservation
+  /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
+  /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
+  /// @param nullifierHash The nullifier for this proof, preventing double signaling
+  /// @param proof The zero knowledge proof, array of 8 uint256 elements, demonstrating that the claimer has a verified World ID
+  /// @param signature The off-chain signature of the reservation.
+  function checkClaimReserved(
+    uint256 timestamp,
+    address receiver,
+    uint256 root,
+    uint256 nullifierHash,
+    uint256[8] calldata proof,
+    bytes calldata signature
+  ) public {
+    uint256 grantId = grant.calculateId(timestamp);
+
+    if (receiver == address(0)) revert InvalidReceiver();
+    if (timestamp > block.timestamp) revert InvalidTimestamp();
+
+    if (nullifierHashes[nullifierHash]) revert InvalidNullifier();
+
+    grant.checkReservationValidity(timestamp);
+
+    address signer = ECDSA.recover(keccak256(abi.encode(timestamp, nullifierHash)), signature);
+    if (!allowedSigners[signer]) revert UnauthorizedSigner();
+
+    worldIdRouter.verifyProof(
+      root,
+      groupId,
+      uint256(keccak256(abi.encodePacked(receiver))) >> 8,
+      nullifierHash,
+      grantId + WORLDCHAIN_NULLIFIER_HASH_PREFIX,
+      proof
     );
+  }
 
-    /// @notice Emitted when a grant is successfully claimed
-    /// @param receiver The address that received the tokens
-    event GrantClaimed(uint256 grantId, address receiver);
+  ///////////////////////////////////////////////////////////////////////////////
+  ///                               CONFIG LOGIC                             ///
+  //////////////////////////////////////////////////////////////////////////////
 
-    /// @notice Emitted when the worldIdRouter is changed
-    /// @param worldIdRouter The new worldIdRouter instance
-    event WorldIdRouterUpdated(IWorldIDGroups worldIdRouter);
+  /// @notice Add a caller to the list of allowed callers
+  /// @param _signer The address to add
+  function addAllowedReservationSigner(address _signer) external onlyOwner {
+    if (_signer == address(0)) revert InvalidReservationSigner();
+    allowedSigners[_signer] = true;
 
-    /// @notice Emitted when the groupId is changed
-    /// @param groupId The new groupId
-    event GroupIdUpdated(uint256 groupId);
+    emit AllowedReservationSignerAdded(_signer);
+  }
 
-    /// @notice Emitted when the token is changed
-    /// @param token The new token
-    event TokenUpdated(ERC20 token);
+  /// @notice Remove a signer to the list of allowed signers
+  /// @param _signer The address to remove
+  function removeAllowedReservationSigner(address _signer) external onlyOwner {
+    if (_signer == address(0)) revert InvalidReservationSigner();
+    allowedSigners[_signer] = false;
 
-    /// @notice Emitted when the holder is changed
-    /// @param holder The new holder
-    event HolderUpdated(address holder);
+    emit AllowedReservationSignerRemoved(_signer);
+  }
 
-    /// @notice Emitted when the grant is changed
-    /// @param grant The new grant instance
-    event GrantUpdated(IGrantReservations grant);
+  /// @notice Update the worldIdRouter
+  /// @param _worldIdRouter The new worldIdRouter
+  function setWorldIdRouter(IWorldIDGroups _worldIdRouter) external onlyOwner {
+    if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
 
-    /// @notice Emitted when an allowed reservation signer is added
-    /// @param signer The new signer
-    event AllowedReservationSignerAdded(address signer);
+    worldIdRouter = _worldIdRouter;
+    emit WorldIdRouterUpdated(_worldIdRouter);
+  }
 
-    /// @notice Emitted when an allowed reservation signer is removed
-    /// @param signer The new signer
-    event AllowedReservationSignerRemoved(address signer);
+  /// @notice Update the groupId
+  /// @param _groupId The new worldIdRouter
+  function setGroupId(uint256 _groupId) external onlyOwner {
+    groupId = _groupId;
 
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                               CONSTRUCTOR                              ///
-    //////////////////////////////////////////////////////////////////////////////
+    emit GroupIdUpdated(_groupId);
+  }
 
-    /// @notice Deploys a WorldIDAirdrop instance
-    /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
-    /// @param _groupId The group ID of the World ID
-    /// @param _token The ERC20 token that will be airdropped
-    /// @param _holder The address holding the tokens that will be airdropped
-    /// @param _grant The grant that contains the amounts and validity
-    constructor(
-        IWorldIDGroups _worldIdRouter,
-        uint256 _groupId,
-        ERC20 _token,
-        address _holder,
-        IGrantReservations _grant
-    ) Ownable(msg.sender) {
-        if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
-        if (address(_token) == address(0)) revert InvalidConfiguration();
-        if (address(_holder) == address(0)) revert InvalidConfiguration();
-        if (address(_grant) == address(0)) revert InvalidConfiguration();
+  /// @notice Update the token
+  /// @param _token The new token
+  function setToken(ERC20 _token) external onlyOwner {
+    if (address(_token) == address(0)) revert InvalidConfiguration();
+    token = _token;
 
-        worldIdRouter = _worldIdRouter;
-        groupId = _groupId;
-        token = _token;
-        holder = _holder;
-        grant = _grant;
+    emit TokenUpdated(_token);
+  }
 
-        emit RecurringGrantDropInitialized(worldIdRouter, groupId, token, holder, grant);
-    }
+  /// @notice Update the holder
+  /// @param _holder The new holder
+  function setHolder(address _holder) external onlyOwner {
+    if (address(_holder) == address(0)) revert InvalidConfiguration();
+    holder = _holder;
 
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                               CLAIM LOGIC                               ///
-    //////////////////////////////////////////////////////////////////////////////
+    emit HolderUpdated(holder);
+  }
 
-    /// @notice Claim a reserved grant from the past
-    /// @param timestamp The timestamp of the reservation
-    /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
-    /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
-    /// @param nullifierHash The nullifier for this proof, preventing double signaling
-    /// @param proof The zero knowledge proof that demonstrates the claimer has a verified World ID
-    /// @param signature The signature of the reservation
-    function claimReserved(
-        uint256 timestamp,
-        address receiver,
-        uint256 root,
-        uint256 nullifierHash,
-        uint256[8] calldata proof,
-        bytes calldata signature
-    ) external {
-        uint256 grantId = grant.calculateId(timestamp);
-        checkClaimReserved(timestamp, receiver, root, nullifierHash, proof, signature);
+  /// @notice Update the grant
+  /// @param _grant The new grant
+  function setGrant(IGrantReservations _grant) external onlyOwner {
+    if (address(_grant) == address(0)) revert InvalidConfiguration();
 
-        nullifierHashes[nullifierHash] = true;
+    grant = _grant;
+    emit GrantUpdated(_grant);
+  }
 
-        SafeERC20.safeTransferFrom(token, holder, receiver, grant.getAmount(grantId));
-
-        emit GrantClaimed(grantId, receiver);
-    }
-
-    /// @notice Check whether a reservation is valid
-    /// @param timestamp The timestamp of the reservation
-    /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
-    /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
-    /// @param nullifierHash The nullifier for this proof, preventing double signaling
-    /// @param proof The zero knowledge proof, array of 8 uint256 elements, demonstrating that the claimer has a verified World ID
-    /// @param signature The off-chain signature of the reservation.
-    function checkClaimReserved(
-        uint256 timestamp,
-        address receiver,
-        uint256 root,
-        uint256 nullifierHash,
-        uint256[8] calldata proof,
-        bytes calldata signature
-    ) public {
-        uint256 grantId = grant.calculateId(timestamp);
-
-        if (receiver == address(0)) revert InvalidReceiver();
-        if (timestamp > block.timestamp) revert InvalidTimestamp();
-
-        if (nullifierHashes[nullifierHash]) revert InvalidNullifier();
-
-        grant.checkReservationValidity(timestamp);
-
-        address signer = ECDSA.recover(keccak256(abi.encode(timestamp, nullifierHash)), signature);
-        if (!allowedSigners[signer]) revert UnauthorizedSigner();
-
-        worldIdRouter.verifyProof(
-            root,
-            groupId,
-            uint256(keccak256(abi.encodePacked(receiver))) >> 8,
-            nullifierHash,
-            grantId,
-            proof
-        );
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    ///                               CONFIG LOGIC                             ///
-    //////////////////////////////////////////////////////////////////////////////
-
-    /// @notice Add a caller to the list of allowed callers
-    /// @param _signer The address to add
-    function addAllowedReservationSigner(address _signer) external onlyOwner {
-        if (_signer == address(0)) revert InvalidReservationSigner();
-        allowedSigners[_signer] = true;
-
-        emit AllowedReservationSignerAdded(_signer);
-    }
-
-    /// @notice Remove a signer to the list of allowed signers
-    /// @param _signer The address to remove
-    function removeAllowedReservationSigner(address _signer) external onlyOwner {
-        if (_signer == address(0)) revert InvalidReservationSigner();
-        allowedSigners[_signer] = false;
-
-        emit AllowedReservationSignerRemoved(_signer);
-    }
-
-    /// @notice Update the worldIdRouter
-    /// @param _worldIdRouter The new worldIdRouter
-    function setWorldIdRouter(IWorldIDGroups _worldIdRouter) external onlyOwner {
-        if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
-
-        worldIdRouter = _worldIdRouter;
-        emit WorldIdRouterUpdated(_worldIdRouter);
-    }
-
-    /// @notice Update the groupId
-    /// @param _groupId The new worldIdRouter
-    function setGroupId(uint256 _groupId) external onlyOwner {
-        groupId = _groupId;
-
-        emit GroupIdUpdated(_groupId);
-    }
-
-    /// @notice Update the token
-    /// @param _token The new token
-    function setToken(ERC20 _token) external onlyOwner {
-        if (address(_token) == address(0)) revert InvalidConfiguration();
-        token = _token;
-
-        emit TokenUpdated(_token);
-    }
-
-    /// @notice Update the holder
-    /// @param _holder The new holder
-    function setHolder(address _holder) external onlyOwner {
-        if (address(_holder) == address(0)) revert InvalidConfiguration();
-        holder = _holder;
-
-        emit HolderUpdated(holder);
-    }
-
-    /// @notice Update the grant
-    /// @param _grant The new grant
-    function setGrant(IGrantReservations _grant) external onlyOwner {
-        if (address(_grant) == address(0)) revert InvalidConfiguration();
-
-        grant = _grant;
-        emit GrantUpdated(_grant);
-    }
-
-    /// @notice Prevents the owner from renouncing ownership
-    /// @dev onlyOwner
-    function renounceOwnership() public view override onlyOwner {
-        revert CannotRenounceOwnership();
-    }
+  /// @notice Prevents the owner from renouncing ownership
+  /// @dev onlyOwner
+  function renounceOwnership() public view override onlyOwner {
+    revert CannotRenounceOwnership();
+  }
 }

--- a/src/RecurringGrantDropReservations.sol
+++ b/src/RecurringGrantDropReservations.sol
@@ -12,277 +12,277 @@ import { ECDSA } from 'openzeppelin-contracts/contracts/utils/cryptography/ECDSA
 /// @title RecurringGrantDropReservations
 /// @author Worldcoin
 contract RecurringGrantDropReservations is Ownable2Step {
-  ///////////////////////////////////////////////////////////////////////////////
-  ///                              CONFIG STORAGE                            ///
-  //////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                              CONFIG STORAGE                            ///
+    //////////////////////////////////////////////////////////////////////////////
 
-  /// @dev The prefix used for the grant ID external nullifier hash
-  uint256 public constant WORLDCHAIN_NULLIFIER_HASH_PREFIX =
-    0x1E00000000000000000000000000000000000000000000000000000000000000;
+    /// @dev The prefix used for the grant ID external nullifier hash
+    uint256 public constant WORLDCHAIN_NULLIFIER_HASH_PREFIX =
+        0x1E00000000000000000000000000000000000000000000000000000000000000;
 
-  /// @dev The WorldID router instance that will be used for managing groups and verifying proofs
-  IWorldIDGroups public worldIdRouter;
+    /// @dev The WorldID router instance that will be used for managing groups and verifying proofs
+    IWorldIDGroups public worldIdRouter;
 
-  /// @dev The World ID group whose participants can claim this airdrop
-  uint256 public groupId;
+    /// @dev The World ID group whose participants can claim this airdrop
+    uint256 public groupId;
 
-  /// @notice The ERC20 token airdropped
-  ERC20 public token;
+    /// @notice The ERC20 token airdropped
+    ERC20 public token;
 
-  /// @notice The address that holds the tokens that are being airdropped
-  /// @dev Make sure the holder has approved spending for this contract!
-  address public holder;
+    /// @notice The address that holds the tokens that are being airdropped
+    /// @dev Make sure the holder has approved spending for this contract!
+    address public holder;
 
-  /// @notice The grant instance used
-  IGrantReservations public grant;
+    /// @notice The grant instance used
+    IGrantReservations public grant;
 
-  /// @dev Whether a nullifier hash has been used already. Used to prevent double-signaling
-  mapping(uint256 => bool) public nullifierHashes;
+    /// @dev Whether a nullifier hash has been used already. Used to prevent double-signaling
+    mapping(uint256 => bool) public nullifierHashes;
 
-  /// @dev Allowed addresses to sign a reservation
-  mapping(address => bool) internal allowedSigners;
+    /// @dev Allowed addresses to sign a reservation
+    mapping(address => bool) internal allowedSigners;
 
-  ///////////////////////////////////////////////////////////////////////////////
-  ///                                  ERRORS                                ///
-  //////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                                  ERRORS                                ///
+    //////////////////////////////////////////////////////////////////////////////
 
-  /// @notice Error in case the configuration is invalid.
-  error InvalidConfiguration();
+    /// @notice Error in case the configuration is invalid.
+    error InvalidConfiguration();
 
-  /// @notice Error in case the receiver is zero address.
-  error InvalidReceiver();
+    /// @notice Error in case the receiver is zero address.
+    error InvalidReceiver();
 
-  /// @notice Error in case the receiver is zero address.
-  error InvalidTimestamp();
+    /// @notice Error in case the receiver is zero address.
+    error InvalidTimestamp();
 
-  /// @notice Thrown when passed an invalid caller address
-  error InvalidReservationSigner();
+    /// @notice Thrown when passed an invalid caller address
+    error InvalidReservationSigner();
 
-  /// @notice Thrown when passed an invalid caller address
-  error UnauthorizedSigner();
+    /// @notice Thrown when passed an invalid caller address
+    error UnauthorizedSigner();
 
-  /// @notice Thrown when attempting to reuse a nullifier
-  error InvalidNullifier();
+    /// @notice Thrown when attempting to reuse a nullifier
+    error InvalidNullifier();
 
-  /// @notice Emmitted in revert if the owner attempts to resign ownership.
-  error CannotRenounceOwnership();
+    /// @notice Emmitted in revert if the owner attempts to resign ownership.
+    error CannotRenounceOwnership();
 
-  ///////////////////////////////////////////////////////////////////////////////
-  ///                                  EVENTS                                ///
-  //////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                                  EVENTS                                ///
+    //////////////////////////////////////////////////////////////////////////////
 
-  /// @notice Emitted when a grant is successfully claimed
-  /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
-  /// @param _groupId The group ID of the World ID
-  /// @param _token The ERC20 token that will be airdropped
-  /// @param _holder The address holding the tokens that will be airdropped
-  /// @param _grant The grant that contains the amounts and validity
-  event RecurringGrantDropInitialized(
-    IWorldIDGroups _worldIdRouter,
-    uint256 _groupId,
-    ERC20 _token,
-    address _holder,
-    IGrantReservations _grant
-  );
-
-  /// @notice Emitted when a grant is successfully claimed
-  /// @param receiver The address that received the tokens
-  event GrantClaimed(uint256 grantId, address receiver);
-
-  /// @notice Emitted when the worldIdRouter is changed
-  /// @param worldIdRouter The new worldIdRouter instance
-  event WorldIdRouterUpdated(IWorldIDGroups worldIdRouter);
-
-  /// @notice Emitted when the groupId is changed
-  /// @param groupId The new groupId
-  event GroupIdUpdated(uint256 groupId);
-
-  /// @notice Emitted when the token is changed
-  /// @param token The new token
-  event TokenUpdated(ERC20 token);
-
-  /// @notice Emitted when the holder is changed
-  /// @param holder The new holder
-  event HolderUpdated(address holder);
-
-  /// @notice Emitted when the grant is changed
-  /// @param grant The new grant instance
-  event GrantUpdated(IGrantReservations grant);
-
-  /// @notice Emitted when an allowed reservation signer is added
-  /// @param signer The new signer
-  event AllowedReservationSignerAdded(address signer);
-
-  /// @notice Emitted when an allowed reservation signer is removed
-  /// @param signer The new signer
-  event AllowedReservationSignerRemoved(address signer);
-
-  ///////////////////////////////////////////////////////////////////////////////
-  ///                               CONSTRUCTOR                              ///
-  //////////////////////////////////////////////////////////////////////////////
-
-  /// @notice Deploys a WorldIDAirdrop instance
-  /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
-  /// @param _groupId The group ID of the World ID
-  /// @param _token The ERC20 token that will be airdropped
-  /// @param _holder The address holding the tokens that will be airdropped
-  /// @param _grant The grant that contains the amounts and validity
-  constructor(
-    IWorldIDGroups _worldIdRouter,
-    uint256 _groupId,
-    ERC20 _token,
-    address _holder,
-    IGrantReservations _grant
-  ) Ownable(msg.sender) {
-    if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
-    if (address(_token) == address(0)) revert InvalidConfiguration();
-    if (address(_holder) == address(0)) revert InvalidConfiguration();
-    if (address(_grant) == address(0)) revert InvalidConfiguration();
-
-    worldIdRouter = _worldIdRouter;
-    groupId = _groupId;
-    token = _token;
-    holder = _holder;
-    grant = _grant;
-
-    emit RecurringGrantDropInitialized(worldIdRouter, groupId, token, holder, grant);
-  }
-
-  ///////////////////////////////////////////////////////////////////////////////
-  ///                               CLAIM LOGIC                               ///
-  //////////////////////////////////////////////////////////////////////////////
-
-  /// @notice Claim a reserved grant from the past
-  /// @param timestamp The timestamp of the reservation
-  /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
-  /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
-  /// @param nullifierHash The nullifier for this proof, preventing double signaling
-  /// @param proof The zero knowledge proof that demonstrates the claimer has a verified World ID
-  /// @param signature The signature of the reservation
-  function claimReserved(
-    uint256 timestamp,
-    address receiver,
-    uint256 root,
-    uint256 nullifierHash,
-    uint256[8] calldata proof,
-    bytes calldata signature
-  ) external {
-    uint256 grantId = grant.calculateId(timestamp);
-    checkClaimReserved(timestamp, receiver, root, nullifierHash, proof, signature);
-
-    nullifierHashes[nullifierHash] = true;
-
-    SafeERC20.safeTransferFrom(token, holder, receiver, grant.getAmount(grantId));
-
-    emit GrantClaimed(grantId, receiver);
-  }
-
-  /// @notice Check whether a reservation is valid
-  /// @param timestamp The timestamp of the reservation
-  /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
-  /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
-  /// @param nullifierHash The nullifier for this proof, preventing double signaling
-  /// @param proof The zero knowledge proof, array of 8 uint256 elements, demonstrating that the claimer has a verified World ID
-  /// @param signature The off-chain signature of the reservation.
-  function checkClaimReserved(
-    uint256 timestamp,
-    address receiver,
-    uint256 root,
-    uint256 nullifierHash,
-    uint256[8] calldata proof,
-    bytes calldata signature
-  ) public {
-    uint256 grantId = grant.calculateId(timestamp);
-
-    if (receiver == address(0)) revert InvalidReceiver();
-    if (timestamp > block.timestamp) revert InvalidTimestamp();
-
-    if (nullifierHashes[nullifierHash]) revert InvalidNullifier();
-
-    grant.checkReservationValidity(timestamp);
-
-    address signer = ECDSA.recover(keccak256(abi.encode(timestamp, nullifierHash)), signature);
-    if (!allowedSigners[signer]) revert UnauthorizedSigner();
-
-    worldIdRouter.verifyProof(
-      root,
-      groupId,
-      uint256(keccak256(abi.encodePacked(receiver))) >> 8,
-      nullifierHash,
-      grantId + WORLDCHAIN_NULLIFIER_HASH_PREFIX,
-      proof
+    /// @notice Emitted when a grant is successfully claimed
+    /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
+    /// @param _groupId The group ID of the World ID
+    /// @param _token The ERC20 token that will be airdropped
+    /// @param _holder The address holding the tokens that will be airdropped
+    /// @param _grant The grant that contains the amounts and validity
+    event RecurringGrantDropInitialized(
+        IWorldIDGroups _worldIdRouter,
+        uint256 _groupId,
+        ERC20 _token,
+        address _holder,
+        IGrantReservations _grant
     );
-  }
 
-  ///////////////////////////////////////////////////////////////////////////////
-  ///                               CONFIG LOGIC                             ///
-  //////////////////////////////////////////////////////////////////////////////
+    /// @notice Emitted when a grant is successfully claimed
+    /// @param receiver The address that received the tokens
+    event GrantClaimed(uint256 grantId, address receiver);
 
-  /// @notice Add a caller to the list of allowed callers
-  /// @param _signer The address to add
-  function addAllowedReservationSigner(address _signer) external onlyOwner {
-    if (_signer == address(0)) revert InvalidReservationSigner();
-    allowedSigners[_signer] = true;
+    /// @notice Emitted when the worldIdRouter is changed
+    /// @param worldIdRouter The new worldIdRouter instance
+    event WorldIdRouterUpdated(IWorldIDGroups worldIdRouter);
 
-    emit AllowedReservationSignerAdded(_signer);
-  }
+    /// @notice Emitted when the groupId is changed
+    /// @param groupId The new groupId
+    event GroupIdUpdated(uint256 groupId);
 
-  /// @notice Remove a signer to the list of allowed signers
-  /// @param _signer The address to remove
-  function removeAllowedReservationSigner(address _signer) external onlyOwner {
-    if (_signer == address(0)) revert InvalidReservationSigner();
-    allowedSigners[_signer] = false;
+    /// @notice Emitted when the token is changed
+    /// @param token The new token
+    event TokenUpdated(ERC20 token);
 
-    emit AllowedReservationSignerRemoved(_signer);
-  }
+    /// @notice Emitted when the holder is changed
+    /// @param holder The new holder
+    event HolderUpdated(address holder);
 
-  /// @notice Update the worldIdRouter
-  /// @param _worldIdRouter The new worldIdRouter
-  function setWorldIdRouter(IWorldIDGroups _worldIdRouter) external onlyOwner {
-    if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
+    /// @notice Emitted when the grant is changed
+    /// @param grant The new grant instance
+    event GrantUpdated(IGrantReservations grant);
 
-    worldIdRouter = _worldIdRouter;
-    emit WorldIdRouterUpdated(_worldIdRouter);
-  }
+    /// @notice Emitted when an allowed reservation signer is added
+    /// @param signer The new signer
+    event AllowedReservationSignerAdded(address signer);
 
-  /// @notice Update the groupId
-  /// @param _groupId The new worldIdRouter
-  function setGroupId(uint256 _groupId) external onlyOwner {
-    groupId = _groupId;
+    /// @notice Emitted when an allowed reservation signer is removed
+    /// @param signer The new signer
+    event AllowedReservationSignerRemoved(address signer);
 
-    emit GroupIdUpdated(_groupId);
-  }
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                               CONSTRUCTOR                              ///
+    //////////////////////////////////////////////////////////////////////////////
 
-  /// @notice Update the token
-  /// @param _token The new token
-  function setToken(ERC20 _token) external onlyOwner {
-    if (address(_token) == address(0)) revert InvalidConfiguration();
-    token = _token;
+    /// @notice Deploys a WorldIDAirdrop instance
+    /// @param _worldIdRouter The WorldID router that will manage groups and verify proofs
+    /// @param _groupId The group ID of the World ID
+    /// @param _token The ERC20 token that will be airdropped
+    /// @param _holder The address holding the tokens that will be airdropped
+    /// @param _grant The grant that contains the amounts and validity
+    constructor(
+        IWorldIDGroups _worldIdRouter,
+        uint256 _groupId,
+        ERC20 _token,
+        address _holder,
+        IGrantReservations _grant
+    ) Ownable(msg.sender) {
+        if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
+        if (address(_token) == address(0)) revert InvalidConfiguration();
+        if (address(_holder) == address(0)) revert InvalidConfiguration();
+        if (address(_grant) == address(0)) revert InvalidConfiguration();
 
-    emit TokenUpdated(_token);
-  }
+        worldIdRouter = _worldIdRouter;
+        groupId = _groupId;
+        token = _token;
+        holder = _holder;
+        grant = _grant;
 
-  /// @notice Update the holder
-  /// @param _holder The new holder
-  function setHolder(address _holder) external onlyOwner {
-    if (address(_holder) == address(0)) revert InvalidConfiguration();
-    holder = _holder;
+        emit RecurringGrantDropInitialized(worldIdRouter, groupId, token, holder, grant);
+    }
 
-    emit HolderUpdated(holder);
-  }
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                               CLAIM LOGIC                               ///
+    //////////////////////////////////////////////////////////////////////////////
 
-  /// @notice Update the grant
-  /// @param _grant The new grant
-  function setGrant(IGrantReservations _grant) external onlyOwner {
-    if (address(_grant) == address(0)) revert InvalidConfiguration();
+    /// @notice Claim a reserved grant from the past
+    /// @param timestamp The timestamp of the reservation
+    /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
+    /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
+    /// @param nullifierHash The nullifier for this proof, preventing double signaling
+    /// @param proof The zero knowledge proof that demonstrates the claimer has a verified World ID
+    /// @param signature The signature of the reservation
+    function claimReserved(
+        uint256 timestamp,
+        address receiver,
+        uint256 root,
+        uint256 nullifierHash,
+        uint256[8] calldata proof,
+        bytes calldata signature
+    ) external {
+        uint256 grantId = grant.calculateId(timestamp);
+        checkClaimReserved(timestamp, receiver, root, nullifierHash, proof, signature);
 
-    grant = _grant;
-    emit GrantUpdated(_grant);
-  }
+        nullifierHashes[nullifierHash] = true;
 
-  /// @notice Prevents the owner from renouncing ownership
-  /// @dev onlyOwner
-  function renounceOwnership() public view override onlyOwner {
-    revert CannotRenounceOwnership();
-  }
+        SafeERC20.safeTransferFrom(token, holder, receiver, grant.getAmount(grantId));
+
+        emit GrantClaimed(grantId, receiver);
+    }
+
+    /// @notice Check whether a reservation is valid
+    /// @param timestamp The timestamp of the reservation
+    /// @param receiver The address that will receive the tokens (this is also the signal of the ZKP)
+    /// @param root The root of the Merkle tree (signup-sequencer or world-id-contracts provides this)
+    /// @param nullifierHash The nullifier for this proof, preventing double signaling
+    /// @param proof The zero knowledge proof, array of 8 uint256 elements, demonstrating that the claimer has a verified World ID
+    /// @param signature The off-chain signature of the reservation.
+    function checkClaimReserved(
+        uint256 timestamp,
+        address receiver,
+        uint256 root,
+        uint256 nullifierHash,
+        uint256[8] calldata proof,
+        bytes calldata signature
+    ) public {
+        uint256 grantId = grant.calculateId(timestamp);
+
+        if (receiver == address(0)) revert InvalidReceiver();
+        if (timestamp > block.timestamp) revert InvalidTimestamp();
+
+        if (nullifierHashes[nullifierHash]) revert InvalidNullifier();
+
+        grant.checkReservationValidity(timestamp);
+
+        address signer = ECDSA.recover(keccak256(abi.encode(timestamp, nullifierHash)), signature);
+        if (!allowedSigners[signer]) revert UnauthorizedSigner();
+
+        worldIdRouter.verifyProof(
+            root,
+            groupId,
+            uint256(keccak256(abi.encodePacked(receiver))) >> 8,
+            nullifierHash,
+            grantId + WORLDCHAIN_NULLIFIER_HASH_PREFIX,
+            proof
+        );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                               CONFIG LOGIC                             ///
+    //////////////////////////////////////////////////////////////////////////////
+
+    /// @notice Add a caller to the list of allowed callers
+    /// @param _signer The address to add
+    function addAllowedReservationSigner(address _signer) external onlyOwner {
+        if (_signer == address(0)) revert InvalidReservationSigner();
+        allowedSigners[_signer] = true;
+
+        emit AllowedReservationSignerAdded(_signer);
+    }
+
+    /// @notice Remove a signer to the list of allowed signers
+    /// @param _signer The address to remove
+    function removeAllowedReservationSigner(address _signer) external onlyOwner {
+        if (_signer == address(0)) revert InvalidReservationSigner();
+        allowedSigners[_signer] = false;
+
+        emit AllowedReservationSignerRemoved(_signer);
+    }
+
+    /// @notice Update the worldIdRouter
+    /// @param _worldIdRouter The new worldIdRouter
+    function setWorldIdRouter(IWorldIDGroups _worldIdRouter) external onlyOwner {
+        if (address(_worldIdRouter) == address(0)) revert InvalidConfiguration();
+
+        worldIdRouter = _worldIdRouter;
+        emit WorldIdRouterUpdated(_worldIdRouter);
+    }
+
+    /// @notice Update the groupId
+    /// @param _groupId The new worldIdRouter
+    function setGroupId(uint256 _groupId) external onlyOwner {
+        groupId = _groupId;
+
+        emit GroupIdUpdated(_groupId);
+    }
+
+    /// @notice Update the token
+    /// @param _token The new token
+    function setToken(ERC20 _token) external onlyOwner {
+        if (address(_token) == address(0)) revert InvalidConfiguration();
+        token = _token;
+
+        emit TokenUpdated(_token);
+    }
+
+    /// @notice Update the holder
+    /// @param _holder The new holder
+    function setHolder(address _holder) external onlyOwner {
+        if (address(_holder) == address(0)) revert InvalidConfiguration();
+        holder = _holder;
+
+        emit HolderUpdated(holder);
+    }
+
+    /// @notice Update the grant
+    /// @param _grant The new grant
+    function setGrant(IGrantReservations _grant) external onlyOwner {
+        if (address(_grant) == address(0)) revert InvalidConfiguration();
+
+        grant = _grant;
+        emit GrantUpdated(_grant);
+    }
+
+    /// @notice Prevents the owner from renouncing ownership
+    /// @dev onlyOwner
+    function renounceOwnership() public view override onlyOwner {
+        revert CannotRenounceOwnership();
+    }
 }

--- a/src/WLDGrantReservations.sol
+++ b/src/WLDGrantReservations.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {IGrantReservations} from "./IGrantReservations.sol";
+
+/**
+ * This is the WLDGrant for grantIds [13;38] post grantId 38
+ * 
+ * While we no longer support claims in this contract for the given range,
+ * we do still accept reservations
+ */
+contract WLDGrantReservations is IGrantReservations {
+    uint256 internal immutable launchDayTimestampInSeconds = 1690167600; // Monday, 24 July 2023 03:00:00
+
+    function calculateId(uint256 timestamp) external pure returns (uint256) {
+        if (timestamp < launchDayTimestampInSeconds) revert InvalidGrant();
+
+        uint256 weeksSinceLaunch = (timestamp - launchDayTimestampInSeconds) / 1 weeks;
+        // Monday, 24 July 2023 07:00:00 until Monday, 07 August 2023 06:59:59 (2 weeks)
+        if (weeksSinceLaunch < 2) return 13;
+        // Monday, 07 August 2023 03:00:00 until Monday, 14 August 2023 02:59:59 (1 week)
+        if (weeksSinceLaunch < 3) return 14;
+        uint256 grantId = 15 + (weeksSinceLaunch - 3) / 2;
+        // Grant 29 is a four-week grant.
+        if (grantId <= 29) return grantId;
+        return grantId - 1;
+    }
+
+    function getCurrentId() external view override returns (uint256) {
+        return this.calculateId(block.timestamp);
+    }
+
+    function getAmount(uint256 grantId) external pure override returns (uint256) {
+        if (grantId == 13) return 25 * 10 ** 18;
+        if (grantId == 14) return 10 * 10 ** 18;
+        if (grantId == 30) return 6 * 10 ** 18;
+        return 3 * 10 ** 18;
+    }
+
+    function checkReservationValidity(uint256 timestamp) external view override {
+        uint256 grantId = this.calculateId(timestamp);
+
+        // No future grants can be claimed.
+        if (grantId >= this.getCurrentId()) revert InvalidGrant();
+
+        // Only grant reservations with grantIds in the range [13;38] can be redeemed.
+        if (grantId < 13 || grantId > 38) revert InvalidGrant();
+    }
+}

--- a/src/test/WLDGrantReservations.t.sol
+++ b/src/test/WLDGrantReservations.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {PRBTest} from "@prb/test/PRBTest.sol";
+import {WLDGrantReservations} from "../WLDGrantReservations.sol";
+import {IGrantReservations} from "../IGrantReservations.sol";
+
+/// @title WLDGrantReservationsTest
+/// @author Worldcoin
+contract WLDGrantReservationsTest is PRBTest {
+    WLDGrantReservations internal grant;
+    uint256 internal constant launchDayTimestampInSeconds = 1690167600; // Monday, 24 July 2023 03:00:00
+    uint256 internal constant grant4LaunchDayTimestampInSeconds = 1722470400; // Thursday, 01 August 2024 00:00:00 GMT
+
+    function setUp() public {
+        grant = new WLDGrantReservations();
+    }
+
+    function test_getAmount_grant13() public {
+        assertEq(grant.getAmount(13), 25 * 10 ** 18);
+    }
+
+    function test_getAmount_grant14() public {
+        assertEq(grant.getAmount(14), 10 * 10 ** 18);
+    }
+
+    function test_getAmount_grant15() public {
+        assertEq(grant.getAmount(15), 3 * 10 ** 18);
+    }
+
+    function test_getAmount_grant30() public {
+        assertEq(grant.getAmount(30), 6 * 10 ** 18);
+    }
+
+    function test_getAmount_grant38() public {
+        assertEq(grant.getAmount(38), 3 * 10 ** 18);
+    }
+
+    function test_checkReservationValidity_grant13() public {
+      vm.warp(grant4LaunchDayTimestampInSeconds);
+      grant.checkReservationValidity(launchDayTimestampInSeconds + 3 days);
+    }
+
+    function test_checkReservationValidity_grant38() public {
+      vm.warp(grant4LaunchDayTimestampInSeconds + 1 weeks);
+      grant.checkReservationValidity(grant4LaunchDayTimestampInSeconds - 1 weeks);
+    }
+
+    function test_checkReservationValidity_revertsGreaterThanGrant38() public {
+      vm.warp(grant4LaunchDayTimestampInSeconds + 10 weeks);
+      vm.expectRevert(abi.encodeWithSelector(IGrantReservations.InvalidGrant.selector));
+      grant.checkReservationValidity(grant4LaunchDayTimestampInSeconds + 1 weeks);
+    }
+
+    function test_checkReservationValidity_revertsLessThan13() public {
+      vm.warp(grant4LaunchDayTimestampInSeconds);
+      vm.expectRevert(abi.encodeWithSelector(IGrantReservations.InvalidGrant.selector));
+      grant.checkReservationValidity(launchDayTimestampInSeconds - 1 weeks);
+    }
+
+    function testFuzz_checkReservationValidityReverts(uint256 timestamp) public {
+      vm.assume(timestamp > grant4LaunchDayTimestampInSeconds || timestamp < launchDayTimestampInSeconds);
+      vm.expectRevert(abi.encodeWithSelector(IGrantReservations.InvalidGrant.selector));
+      grant.checkReservationValidity(timestamp);
+    }
+
+    function test_checkReservation_grant37() public {
+      vm.warp(grant4LaunchDayTimestampInSeconds - (1 weeks));
+      grant.checkReservationValidity(grant4LaunchDayTimestampInSeconds - (4 weeks));
+    }
+
+    function test_checkReservation_grant38() public {
+      vm.warp(grant4LaunchDayTimestampInSeconds);
+      grant.checkReservationValidity(grant4LaunchDayTimestampInSeconds - (1 weeks));
+    }
+}


### PR DESCRIPTION
This PR adds ReservationsOnly claims contracts for worldchain. It uses the same worldchain constant for the nullifier hash as the worldchain RGD (it's not technically required to have for reservations but we do it for all claims contracts on worldchain for consistency)

NOTE: Technically, this PR adjusts an existing ReservationsOnly contract in the repo that was created as a backup on optimism but never deployed